### PR TITLE
Incorrect prefix for frequency in channel field.

### DIFF
--- a/fields/Channel.md
+++ b/fields/Channel.md
@@ -12,9 +12,9 @@ Required Alignment
 : 2
 
 Units
-: MHz, bitmap
+: KHz, bitmap
 
-Tx/Rx frequency in MHz, followed by flags.
+Tx/Rx frequency in KHz, followed by flags.
 
 Currently, the following flags are defined:
 


### PR DESCRIPTION
This PR corrects the page for the channel field. In the old version it red MHz instead of KHz for frequency. I'm no expert, but I would be surprised if WiFi was operating on 5 terahertz ;)