### PR TITLE
Antenna: fix typo in type number

### DIFF
--- a/fields/Antenna.md
+++ b/fields/Antenna.md
@@ -1,7 +1,7 @@
 ---
 title: Antenna
 categories: [defined]
-type: 21
+type: 11
 ---
 Bit Number
 : 11


### PR DESCRIPTION
Antenna field is defined as bit number 11, while the type identifier was 21, clashing with VHT field.